### PR TITLE
Prey - Do not crash on loading mods

### DIFF
--- a/Q3E/src/main/jni/doom3/neo/framework/Session.cpp
+++ b/Q3E/src/main/jni/doom3/neo/framework/Session.cpp
@@ -3997,6 +3997,9 @@ const char * idSessionLocal::GetDeathwalkMapName(const char *mapName) const
 		return "";
 #endif
 	const idDeclEntityDef *mapDef = static_cast<const idDeclEntityDef *>(mapDecl);
+	if (!mapDef) {
+		return "";
+	}
 	const char *dwMap = mapDef->dict.GetString("deathwalkmap");
 	if(!dwMap || !dwMap[0])
 		return "";


### PR DESCRIPTION
This PR fixes loading of following Prey2006 mods:
* Altered Reality
* LeonPrey
* Lost City
* Prey Revelations
* Surprisingly Focused
* Who's Home?