### PR TITLE
Prey - Alien text translation logic fixed

### DIFF
--- a/Q3E/src/main/jni/doom3/neo/prey/Prey/game_player.cpp
+++ b/Q3E/src/main/jni/doom3/neo/prey/Prey/game_player.cpp
@@ -1970,7 +1970,23 @@ void hhPlayer::UpdateFocus( void ) {
 
 #ifdef _PREY //k: auto translate alien text
 	const char *translateAlienFont = harm_g_translateAlienFont.GetString();
-	const bool translateAlien = translateAlienFont && translateAlienFont[0];
+
+	if (talon.IsValid() && translateAlienFont && translateAlienFont[0]) {
+		for ( auto e : gameLocal.entities ) {
+			if ( !e || e->IsHidden() ) {
+				continue;
+			}
+
+			renderEntity_t *renderEnt = e->GetRenderEntity();
+			if ( renderEnt ) {
+				for (int ix=0; ix<MAX_RENDERENTITY_GUI; ix++) {
+					if (renderEnt->gui[ix] && ((talon->GetOrigin() - renderEnt->origin).Length() < 200)) {
+						renderEnt->gui[ix]->Translate(translateAlienFont);
+					}
+				}
+			}
+		}
+	}
 #endif
 
 	// no pretense at sorting here, just assume that there will only be one active
@@ -1991,11 +2007,6 @@ void hhPlayer::UpdateFocus( void ) {
 				if (renderEnt->gui[ix] && renderEnt->gui[ix]->IsInteractive()) {
 					interactiveMask |= (1<<ix);
 				}
-#ifdef _PREY //k: auto translate alien text
-				if ( renderEnt->gui[ix] && translateAlien ) {
-					renderEnt->gui[ix]->Translate(translateAlienFont);
-				}
-#endif
 			}
 		}
 		if (!interactiveMask) {


### PR DESCRIPTION
In Prey the alien text should be translated only when Talon is near the object. This PR fixes that issue.