### PR TITLE
Fixed compiling with AndroidIDE v. 2.5.3-beta and dropped android 4.0…

### DIFF
--- a/Q3E/build.gradle
+++ b/Q3E/build.gradle
@@ -3,10 +3,11 @@ apply plugin: 'com.android.library'
 android {
     compileSdk 30
     buildToolsVersion '30.0.3'
+    ndkVersion '23.2.8568313'
     //compileOptions.encoding "gbk"
 
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion 16
         targetSdkVersion 30
 
         ndk {

--- a/Q3E/src/main/jni/doom3/neo/mod/doom3/hexeneoc/PlayerArtifacts.cpp
+++ b/Q3E/src/main/jni/doom3/neo/mod/doom3/hexeneoc/PlayerArtifacts.cpp
@@ -5,7 +5,7 @@
 #include "Game_local.h"
 #include "Item.h"
 #include "Player.h"
-#include "gameSys/SysCvar.h"
+#include "gamesys/SysCvar.h"
 
 int idPlayer::FindArtifact( int art ) {
 	for (int belt=0; belt<Artifact.Num(); belt++) {

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 **Arch:**
 arm64 armv7-a  
 **Platform:**
-Android 4.0+  
+Android 4.1+  
 **License:**
 GPLv3
 

--- a/idTech4Amm/build.gradle
+++ b/idTech4Amm/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.android.application'
 android {
     compileSdk 30
     buildToolsVersion '30.0.3'
+    ndkVersion '23.2.8568313'
     //compileOptions.encoding "gbk"
 
     /* not AIDE */
@@ -10,7 +11,7 @@ android {
         debug {
             v1SigningEnabled true
             v2SigningEnabled true
-            storeFile file('F:\\qobj\\droid\\DIII4A\\idtech4amm.keystore')
+            storeFile file('../idtech4amm.keystore')
             storePassword '741953'
             keyAlias 'idtech4amm'
             keyPassword '741953'
@@ -18,7 +19,7 @@ android {
         release {
             v1SigningEnabled true
             v2SigningEnabled true
-            storeFile file('F:\\qobj\\droid\\DIII4A\\idtech4amm.keystore')
+            storeFile file('../idtech4amm.keystore')
             storePassword '741953'
             keyAlias 'idtech4amm'
             keyPassword '741953'
@@ -27,7 +28,7 @@ android {
 
     defaultConfig {
         applicationId "com.karin.idTech4Amm"
-        minSdkVersion 14
+        minSdkVersion 16
         targetSdkVersion 30
         versionCode 11035
         versionName '1.1.0harmattan35'
@@ -40,6 +41,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
+            signingConfig signingConfigs.release
         }
     }
     lintOptions {


### PR DESCRIPTION
… support, it must be 4.1 or above because AndroidIDE supports minSdkVersion not less than 16