### PR TITLE
Added fixes for some build errors and support for the e2k architecture

### DIFF
--- a/Q3E/src/main/jni/doom3/neo/CMakeLists.txt
+++ b/Q3E/src/main/jni/doom3/neo/CMakeLists.txt
@@ -1620,6 +1620,7 @@ if(CORE)
 		idlib
 		${sys_libs}
 		${local_libs}
+		pthread
 	)
 
 	install(TARGETS ${DOOM3BINARY}
@@ -1838,6 +1839,7 @@ if(RAVEN)
 			idlib_raven
 			${sys_libs}
 			${local_libs}
+			pthread
 			)
 
 	install(TARGETS ${QUAKE4BINARY}
@@ -1903,6 +1905,7 @@ if(HUMANHEAD)
 			idlib_humanhead
 			${sys_libs}
 			${local_libs}
+			pthread
 			)
 
 	install(TARGETS ${PREYBINARY}

--- a/Q3E/src/main/jni/doom3/neo/prey/gamesys/Class.h
+++ b/Q3E/src/main/jni/doom3/neo/prey/gamesys/Class.h
@@ -45,7 +45,7 @@ public:
 	idEventArg( const struct trace_s *data )	{ type = D_EVENT_TRACE; value = reinterpret_cast<intptr_t>( data ); };
 #ifdef _PREY //k: placeholder for NULL
 	// only call in C++: game_anim.cpp::hhAnim::CallFrameCommandsExtra -> entity->ProcessEvent( &idEventDef, time, (intptr_t)ptr )
-#if defined(__aarch64__) || defined(__x86_64__)
+#if defined(__aarch64__) || defined(__x86_64__) || defined(__e2k__)
 	idEventArg(intptr_t data) { type = D_EVENT_INTPTR; value = data; };
 #endif
 #endif

--- a/Q3E/src/main/jni/doom3/neo/prey/gamesys/Event.cpp
+++ b/Q3E/src/main/jni/doom3/neo/prey/gamesys/Event.cpp
@@ -110,7 +110,7 @@ idEventDef::idEventDef( const char *command, const char *formatspec, char return
 			break;
 
 #ifdef _PREY
-#if defined(__aarch64__) || defined(__x86_64__)
+#if defined(__aarch64__) || defined(__x86_64__) || defined(__e2k__)
 		case D_EVENT_INTPTR:
 			argsize += sizeof(intptr_t);
 			break;

--- a/Q3E/src/main/jni/doom3/neo/prey/gamesys/Event.h
+++ b/Q3E/src/main/jni/doom3/neo/prey/gamesys/Event.h
@@ -23,7 +23,7 @@ Event are used for scheduling tasks and for linking script commands.
 #define MAX_EVENTS					4096
 
 #ifdef _PREY
-#if defined(__aarch64__) || defined(__x86_64__)
+#if defined(__aarch64__) || defined(__x86_64__) || defined(__e2k__)
 #define D_EVENT_INTPTR		'y'
 #endif
 #endif

--- a/Q3E/src/main/jni/doom3/neo/quake4/ai/AI_Move.cpp
+++ b/Q3E/src/main/jni/doom3/neo/quake4/ai/AI_Move.cpp
@@ -3889,10 +3889,10 @@ public:
 
 	/*
 	=====================
-	Success
+	success
 	=====================
 	*/
-	bool	Success(visitNode* node) {
+	bool	success(visitNode* node) {
 		static idVec3		edgeA;
 		static idVec3		edgeB;
 		static idVec3		intersect;
@@ -4384,13 +4384,13 @@ public:
 			// Test For Any Obstacles In The Way
 			//-----------------------------------
 			if (!obstacleFinder.RayTrace(0.0f, myArea, myMove->myPos, myMove->goalPos, 0/*CDR_TODO: Get myAASNum*/, myIgnoreEntity, myIgnoreEntity2)) {
-				return Success(NULL);
+				return success(NULL);
 			}
 
 			// If There Is An Obstacle But We Think We Can Steer Around It, Then We've Still Succeeded
 			//-----------------------------------------------------------------------------------------
 			if (obstacleFinder.contact.v1Valid || obstacleFinder.contact.v2Valid) {
-				return Success(NULL);
+				return success(NULL);
 			}
 		}
 
@@ -4420,13 +4420,13 @@ public:
 				// Test For Any Obstacles In The Way
 				//-----------------------------------
 				if (!obstacleFinder.RayTrace(0.0f, goalArea, GetSeekPosition(next), myMove->goalPos, 0/*CDR_TODO: Get myAASNum*/, myIgnoreEntity, myIgnoreEntity2)) {
-					return Success(next);
+					return success(next);
 				}
 
 				// Or If There Is An Obstacle, But One Of The Verts Is Valid, Then This Is Still A Safe Course
 				//---------------------------------------------------------------------------------------------
 				if (obstacleFinder.contact.v1Valid || obstacleFinder.contact.v2Valid) {
-					return Success(next);
+					return success(next);
 				}
 
 			// Visit All Reaches In The Next Area

--- a/Q3E/src/main/jni/doom3/neo/quake4/gamesys/Class.h
+++ b/Q3E/src/main/jni/doom3/neo/quake4/gamesys/Class.h
@@ -45,7 +45,7 @@ public:
 
 #ifdef _QUAKE4 // 64bit this can't be called from doomscript!
 	// only call in C++: Anim_Blend.cpp::idAnim::CallFrameCommands, Camera.cpp::rvCameraAnimation::CallFrameCommands -> entity->ProcessEvent( &idEventDef, time, (intptr_t)ptr )
-#if defined(__aarch64__) || defined(__x86_64__)
+#if defined(__aarch64__) || defined(__x86_64__) || defined(__e2k__)
 	idEventArg(intptr_t data) { type = D_EVENT_INTEGER64bit; value = data; };
 #endif
 #endif

--- a/Q3E/src/main/jni/doom3/neo/quake4/gamesys/Event.cpp
+++ b/Q3E/src/main/jni/doom3/neo/quake4/gamesys/Event.cpp
@@ -92,7 +92,7 @@ idEventDef::idEventDef( const char *command, const char *formatspec, char return
 			argsize += sizeof( trace_t ) + MAX_STRING_LEN + sizeof( bool );
 			break;
 #ifdef _QUAKE4
-#if defined(__aarch64__) || defined(__x86_64__)
+#if defined(__aarch64__) || defined(__x86_64__) || defined(__e2k__)
 		case D_EVENT_INTEGER64bit:
 			argsize += sizeof( intptr_t );
 			break;
@@ -343,7 +343,7 @@ idEvent *idEvent::Alloc( const idEventDef *evdef, int numargs, va_list args ) {
 			}
 			break;
 #ifdef _QUAKE4
-#if defined(__aarch64__) || defined(__x86_64__)
+#if defined(__aarch64__) || defined(__x86_64__) || defined(__e2k__)
 		case D_EVENT_INTEGER64bit:
 			*reinterpret_cast<intptr_t *>( dataPtr ) = arg->value;
 			break;

--- a/Q3E/src/main/jni/doom3/neo/raven/bse/BSE_Decl.cpp
+++ b/Q3E/src/main/jni/doom3/neo/raven/bse/BSE_Decl.cpp
@@ -146,7 +146,7 @@ bool rvDeclEffect::SetDefaultText()
 {
 	char generated[1024]; // [esp+4h] [ebp-404h]
 
-	idStr::snPrintf(generated, sizeof(generated), "effect %s // IMPLICITLY GENERATED\n");
+	idStr::snPrintf(generated, sizeof(generated), "effect %s // IMPLICITLY GENERATED\n" , GetName());
 	SetText(generated);
 	return false;
 }

--- a/Q3E/src/main/jni/doom3/neo/sys/sys_public.h
+++ b/Q3E/src/main/jni/doom3/neo/sys/sys_public.h
@@ -161,6 +161,10 @@ enum sysPath_t {
 #define	BUILD_STRING				"linux-arm64"
 #define CPUSTRING					"arm64"
 #define BUILD_OS_ID					2
+#elif defined(__e2k__)
+#define	BUILD_STRING				"linux-e2k"
+#define CPUSTRING					"e2k"
+#define BUILD_OS_ID					2
 #endif
 
 #endif


### PR DESCRIPTION
Through joint efforts, we were able to add initial support for the e2k architecture. During the assembly process, the following errors were found and described ways to fix them.

Ref: https://lvee.org/en/abstracts/303