### PR TITLE
Launcher: Enable mod selection setting for Quake1

### DIFF
--- a/Q3E/src/main/java/com/n0n3m4/q3e/Q3EInterface.java
+++ b/Q3E/src/main/java/com/n0n3m4/q3e/Q3EInterface.java
@@ -380,7 +380,7 @@ public class Q3EInterface
 
 	public void SetupTDM()
 	{
-		isD3 = false; // true
+		isD3 = true;
 		isPrey = false;
 		isQ4 = false;
 		isTDM = true;
@@ -507,7 +507,7 @@ public class Q3EInterface
 		else if(isTDM)
 			return "fs_mod";
 		else if(isQ1)
-			return "game";
+			return "-game";
 		else if(isD3BFG)
 			return "fs_game";
 		else

--- a/Q3E/src/main/java/com/n0n3m4/q3e/karin/KidTech4Command.java
+++ b/Q3E/src/main/java/com/n0n3m4/q3e/karin/KidTech4Command.java
@@ -48,7 +48,15 @@ public final class KidTech4Command
     public static String SetProp(String str, String name, Object val)
     {
         str = PreCmd(str);
-        String nname = " +set " + name;
+        String nname;
+        if(name == "-game")
+        {
+        nname = " " + name;
+        }
+        else
+        {
+         nname = " +set " + name;
+        }
         String insertCmd = val.toString().trim();
         if (str.contains(nname))
         {
@@ -82,7 +90,16 @@ public final class KidTech4Command
     public static String GetProp(String str, String name, String...def)
     {
         str = PreCmd(str);
-        String nname = " +set " + name + " ";
+        //String nname = " +set " + name + " ";
+        String nname;
+        if(name == "-game")
+        {
+        nname = " " + name + "";
+        }
+        else
+        {
+         nname = " +set " + name + " ";
+        }
         String defVal = null != def && def.length > 0 ? def[0] : null;
         String val = defVal;
         if (str.contains(nname))
@@ -102,7 +119,16 @@ public final class KidTech4Command
     public static String RemoveProp(String str, String name, boolean[]...b)
     {
         str = PreCmd(str);
-        String nname = " +set " + name;
+        //String nname = " +set " + name;
+        String nname;
+        if(name == "-game")
+        {
+        nname = " " + name;
+        }
+        else
+        {
+         nname = " +set " + name;
+        }
         boolean res = false;
         if (str.contains(nname))
         {
@@ -134,7 +160,16 @@ public final class KidTech4Command
     public static boolean IsProp(String str, String name)
     {
         str = PreCmd(str);
-        String nname = " +set " + name;
+        //String nname = " +set " + name;
+        String nname;
+        if(name == "-game")
+        {
+        nname = " " + name;
+        }
+        else
+        {
+         nname = " +set " + name;
+        }
         int start = str.indexOf(nname) + nname.length();
         if(start == str.length()) // at last
             return true;

--- a/idTech4Amm/src/main/java/com/n0n3m4/DIII4A/GameLauncher.java
+++ b/idTech4Amm/src/main/java/com/n0n3m4/DIII4A/GameLauncher.java
@@ -968,11 +968,11 @@ public class GameLauncher extends Activity
         V.launcher_tab2_enable_gyro.setChecked(mPrefs.getBoolean(Q3EPreference.pref_harm_view_motion_control_gyro, false));
 		boolean skipIntro = mPrefs.getBoolean(Q3EPreference.pref_harm_skip_intro, false);
 		V.skip_intro.setChecked(skipIntro);
-		if (skipIntro && (Q3EUtils.q3ei.IsIdTech4() || Q3EUtils.q3ei.IsIdTech3()))
+		if (skipIntro)
 			SetCommand_temp("disconnect", true);
         boolean autoQuickLoad = mPrefs.getBoolean(Q3EPreference.pref_harm_auto_quick_load, false);
         V.auto_quick_load.setChecked(autoQuickLoad);
-        if (autoQuickLoad && (Q3EUtils.q3ei.IsIdTech4() || Q3EUtils.q3ei.isRTCW))
+        if (autoQuickLoad && (Q3EUtils.q3ei.IsIdTech4() || Q3EUtils.q3ei.IsIdTech3() || Q3EUtils.q3ei.IsTDMTech()))
             SetParam_temp("loadGame", "QuickSave");
         boolean multithreading = mPrefs.getBoolean(Q3EPreference.pref_harm_multithreading, false);
         V.multithreading.setChecked(multithreading);
@@ -2028,7 +2028,7 @@ public class GameLauncher extends Activity
 			soundVisible = false;
 			otherVisible = false;
 			openglVisible = false;
-			modVisible = false;
+			//modVisible = false;
 			dllVisible = false;
 			quickloadVisible = false;
 			skipintroVisible = false;
@@ -2164,9 +2164,6 @@ public class GameLauncher extends Activity
 		GameManager.GameProp prop = m_gameManager.ChangeGameMod(game, userMod);
 		HandleGameProp(prop);
 		SelectCheckbox(GetGameModRadioGroup(), prop.index);
-
-		Q3EUtils.q3ei.start_temporary_extra_command = GetTempBaseCommand();
-		UpdateTempCommand();
     }
 
 	private void SetupCommandTextWatcher(boolean b)
@@ -2357,10 +2354,10 @@ public class GameLauncher extends Activity
 		SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(GameLauncher.this);
 		String tempCmd = "";
 		boolean skipIntro = preferences.getBoolean(Q3EPreference.pref_harm_skip_intro, false);
-		if (skipIntro && (Q3EUtils.q3ei.IsIdTech4() || Q3EUtils.q3ei.IsIdTech3()))
+		if (skipIntro)
 			tempCmd += " +disconnect";
 		boolean quickSave = preferences.getBoolean(Q3EPreference.pref_harm_auto_quick_load, false);
-		if (quickSave && (Q3EUtils.q3ei.IsIdTech4() || Q3EUtils.q3ei.isRTCW))
+		if (quickSave && (Q3EUtils.q3ei.IsIdTech4() || Q3EUtils.q3ei.IsIdTech3() || Q3EUtils.q3ei.IsTDMTech()))
 			tempCmd += " +loadGame QuickSave";
 		return tempCmd.trim();
 	}


### PR DESCRIPTION
Can you check this PR, is it OK? But the java fileBrowser does not scan the subfolders of the darkplaces/ folder, maybe it is possible to scan them when the launcher is in the quake1 mode?